### PR TITLE
Added RPM spec

### DIFF
--- a/govready.spec
+++ b/govready.spec
@@ -1,0 +1,45 @@
+%define proj govready
+Name:           %{proj}
+Version:        0.6.0
+Release:        1%{?dist}
+Summary:        Software audit and compliance for developers
+Group:          Utilities/Security
+License:        Apache 2.0
+URL:            http://www.gitmachines.com
+Prefix:         /opt
+BuildArch:      noarch
+#BuildRoot:      %{_tmppath}/%{name}-RPM_BUILD_ROOT
+Source0:        %{proj}-%{version}.tar.gz
+Requires:       epel-release >= 6-8,openscap,scap-security-guide,nss >= 3.15.3
+
+%description
+Govready package
+
+%install
+rm -rf ${RPM_BUILD_ROOT}
+install -m 0755 -d ${RPM_BUILD_ROOT}/opt/govready
+#install -m 0755 {scripts,prototypes,templates} ${RPM_BUILD_ROOT}/opt/%{proj}/
+# sloppy
+cp -r * ${RPM_BUILD_ROOT}/opt/%{proj}/
+rm -f ${RPM_BUILD_ROOT}/%{proj}.spec
+
+%prep
+%setup -q %{proj}
+
+%clean
+rm -rf ${RPM_BUILD_ROOT}
+
+%build
+
+%files
+%dir /opt/%{proj}
+%defattr(-,root,root,-)
+%doc README.md
+%doc docs/*
+/opt/%{proj}/*
+
+%post
+
+%changelog
+* Sat Jan 17 2015 Devon Kim <djk29a at gmail dot com> 0.6.0-1
+- Initial RPM


### PR DESCRIPTION
Requires the source directory be in the layout of the RPM builder's SOURCES directory as `govready-0.6.0` (or whatever the version is).

````
[dk@new-host-2 noarch]$ pwd
/home/dk/rpmbuild/RPMS/noarch
[dk@new-host-2 noarch]$ ls ../../SOURCES/
govready-0.6.0  govready-0.6.0.tar.gz
[dk@new-host-2 noarch]$ sudo yum localinstall govready-0.6.0-1.el6.noarch.rpm 
Loaded plugins: fastestmirror, refresh-packagekit, security
Setting up Local Package Process
Examining govready-0.6.0-1.el6.noarch.rpm: govready-0.6.0-1.el6.noarch
Marking govready-0.6.0-1.el6.noarch.rpm to be installed
Loading mirror speeds from cached hostfile
 * base: bay.uchicago.edu
 * epel: ftp.linux.ncsu.edu
 * extras: bay.uchicago.edu
 * updates: centos.aol.com
Resolving Dependencies
--> Running transaction check
---> Package govready.noarch 0:0.6.0-1.el6 will be installed
--> Processing Dependency: openscap for package: govready-0.6.0-1.el6.noarch
--> Processing Dependency: scap-security-guide for package: govready-0.6.0-1.el6.noarch
--> Running transaction check
---> Package openscap.x86_64 0:1.0.8-1.0.1.el6.centos.1 will be installed
---> Package scap-security-guide.noarch 0:0.1.18-3.el6 will be installed
--> Processing Dependency: openscap-utils >= 0.9.1 for package: scap-security-guide-0.1.18-3.el6.noarch
--> Running transaction check
---> Package openscap-utils.x86_64 0:1.0.8-1.0.1.el6.centos.1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

=======================================================================================================================================
 Package                        Arch              Version                                Repository                               Size
=======================================================================================================================================
Installing:
 govready                       noarch            0.6.0-1.el6                            /govready-0.6.0-1.el6.noarch             25 M
Installing for dependencies:
 openscap                       x86_64            1.0.8-1.0.1.el6.centos.1               base                                    2.9 M
 openscap-utils                 x86_64            1.0.8-1.0.1.el6.centos.1               base                                     52 k
 scap-security-guide            noarch            0.1.18-3.el6                           base                                    824 k

Transaction Summary
=======================================================================================================================================
Install       4 Package(s)

Total size: 28 M
Total download size: 3.7 M
Installed size: 76 M
Is this ok [y/N]: 
````