### PR TITLE
Super minor UX change that puts each remote host in their own subdirectory

### DIFF
--- a/govready
+++ b/govready
@@ -818,7 +818,7 @@ _parse_config(){
     # Check to see if we are to scan a remote machine using oscap-ssh.
     if [ -n "${OSCAP_USER+x}" ] && [ -n "${OSCAP_HOST+x}" ] && [ -n "${OSCAP_PORT+x}" ]; then
         OSCAP_COMMAND="oscap-ssh ${OSCAP_USER}@${OSCAP_HOST} ${OSCAP_PORT}"
-        RESULTS_DIR=${SCANDIR}/${PROFILE}-${OSCAP_HOST}
+        RESULTS_DIR=${SCANDIR}/${PROFILE}/${OSCAP_HOST}
         SSH_HOST="${OSCAP_USER}@${OSCAP_HOST}"
         SSH_PORT=${OSCAP_PORT}
         OSCAP_SSH=true


### PR DESCRIPTION
Not sure why it says it can't automatically merge this - seems to be a single character change. I'm using this change now for a client and it's much better for remote scanning.